### PR TITLE
fix cmake configuration list on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,6 +11,7 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 
 #-----------------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-contrib)
 
 include(common)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,32 +14,13 @@ list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 include(add_dev_configuration)
 project(osmium-contrib)
 
-include(common)
+enable_testing()
 
-find_package(Boost REQUIRED COMPONENTS program_options system filesystem)
-include_directories(SYSTEM ${Boost_INCLUDE_DIRS})
-
-find_package(Osmium REQUIRED COMPONENTS io gdal proj sparsehash)
-include_directories(SYSTEM ${OSMIUM_INCLUDE_DIRS})
-
-
-#-----------------------------------------------------------------------------
-#
-#  Configure all subprojects on their own
-#
-#-----------------------------------------------------------------------------
-macro(configure_subproject _subproject)
-    file(GLOB SOURCES ${_subproject}/*.cpp ${_subproject}/*.hpp)
-    add_executable(${_subproject} ${SOURCES})
-    target_link_libraries(${_subproject} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
-endmacro()
-
-configure_subproject(amenity_list)
-configure_subproject(export_to_wkt)
-configure_subproject(mapolution)
-configure_subproject(node_density)
-configure_subproject(pub_names)
-configure_subproject(road_length)
-
+add_subdirectory(amenity_list)
+add_subdirectory(export_to_wkt)
+add_subdirectory(mapolution)
+add_subdirectory(node_density)
+add_subdirectory(pub_names)
+add_subdirectory(road_length)
 
 #-----------------------------------------------------------------------------

--- a/amenity_list/CMakeLists.txt
+++ b/amenity_list/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-amenity-list)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/amenity_list/CMakeLists.txt
+++ b/amenity_list/CMakeLists.txt
@@ -29,10 +29,7 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME amenity_list_node
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND amenity_list ${CMAKE_CURRENT_SOURCE_DIR}/test/node.osm
-)
+add_test(amenity_list_node amenity_list  ${CMAKE_CURRENT_SOURCE_DIR}/test/node.osm)
 set_tests_properties(amenity_list_node PROPERTIES
                      PASS_REGULAR_EXPRESSION "  8\\.8721, 53\\.0966 post_office"
 )

--- a/amenity_list/CMakeLists.txt
+++ b/amenity_list/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-amenity-list)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-amenity-list)
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/cmake/add_dev_configuration.cmake
+++ b/cmake/add_dev_configuration.cmake
@@ -1,0 +1,11 @@
+#-----------------------------------------------------------------------------
+#
+#  Modification of configuration types, adding Dev configuration.
+#  should be included before project() to avoid cmake problems with MSVC
+#
+#-----------------------------------------------------------------------------
+
+set(CMAKE_CONFIGURATION_TYPES "Debug;Release;RelWithDebInfo;MinSizeRel;Dev"
+    CACHE STRING
+    "List of available configuration types"
+    FORCE)

--- a/export_to_wkt/CMakeLists.txt
+++ b/export_to_wkt/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-amenity-list)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/export_to_wkt/CMakeLists.txt
+++ b/export_to_wkt/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-amenity-list)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-amenity-list)
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/export_to_wkt/CMakeLists.txt
+++ b/export_to_wkt/CMakeLists.txt
@@ -29,10 +29,9 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME export_to_wkt
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND export_to_wkt ${CMAKE_CURRENT_SOURCE_DIR}/test/node.osm
-)
+
+add_test(export_to_wkt export_to_wkt ${CMAKE_CURRENT_SOURCE_DIR}/test/node.osm)
+
 set_tests_properties(export_to_wkt PROPERTIES
                      PASS_REGULAR_EXPRESSION "n24960505 POINT\\(8\\.8720536 53\\.096629\\)\n"
 )

--- a/mapolution/CMakeLists.txt
+++ b/mapolution/CMakeLists.txt
@@ -36,10 +36,8 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME mapolution_help
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND mapolution --help
-)
+add_test(mapolution_help mapolution --help)
+
 set_tests_properties(mapolution_help PROPERTIES
                      PASS_REGULAR_EXPRESSION "Usage: mapolution"
 )

--- a/mapolution/CMakeLists.txt
+++ b/mapolution/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-mapolution)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-mapolution)
 
 find_package(Boost REQUIRED COMPONENTS program_options filesystem system)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/mapolution/CMakeLists.txt
+++ b/mapolution/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-mapolution)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED COMPONENTS program_options filesystem system)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/node_density/CMakeLists.txt
+++ b/node_density/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-node-density)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-node-density)
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/node_density/CMakeLists.txt
+++ b/node_density/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-node-density)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED COMPONENTS program_options)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/node_density/CMakeLists.txt
+++ b/node_density/CMakeLists.txt
@@ -29,10 +29,8 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME node_density_help
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND node_density --help
-)
+add_test(node_density_help node_density --help)
+
 set_tests_properties(node_density_help PROPERTIES
                      PASS_REGULAR_EXPRESSION "Usage: node_density"
 )

--- a/pub_names/CMakeLists.txt
+++ b/pub_names/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-pub-names)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-pub-names)
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/pub_names/CMakeLists.txt
+++ b/pub_names/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-pub-names)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/pub_names/CMakeLists.txt
+++ b/pub_names/CMakeLists.txt
@@ -29,10 +29,8 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME pub_names
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND pub_names ${CMAKE_CURRENT_SOURCE_DIR}/test/pubs.osm
-)
+add_test(pub_names pub_names ${CMAKE_CURRENT_SOURCE_DIR}/test/pubs.osm)
+
 set_tests_properties(pub_names PROPERTIES
                      PASS_REGULAR_EXPRESSION "^Im Holze\n$"
 )

--- a/road_length/CMakeLists.txt
+++ b/road_length/CMakeLists.txt
@@ -29,10 +29,8 @@ file(GLOB SOURCES *.cpp *.hpp)
 add_executable(${PROG} ${SOURCES})
 target_link_libraries(${PROG} ${Boost_LIBRARIES} ${OSMIUM_LIBRARIES})
 
-add_test(NAME road_length
-         WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
-         COMMAND road_length ${CMAKE_CURRENT_SOURCE_DIR}/test/road.osm
-)
+add_test(road_length road_length ${CMAKE_CURRENT_SOURCE_DIR}/test/road.osm)
+
 set_tests_properties(road_length PROPERTIES
                      PASS_REGULAR_EXPRESSION "^Length: 0\\.405.*km\n$"
 )

--- a/road_length/CMakeLists.txt
+++ b/road_length/CMakeLists.txt
@@ -3,10 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
+include(add_dev_configuration)
 project(osmium-road-length)
 
 cmake_minimum_required(VERSION 2.8.5)
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/../cmake")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})

--- a/road_length/CMakeLists.txt
+++ b/road_length/CMakeLists.txt
@@ -3,11 +3,11 @@
 #  Single example osmium-contrib CMakeLists.txt
 #
 #----------------------------------------------------------------------
-include(add_dev_configuration)
-project(osmium-road-length)
-
 cmake_minimum_required(VERSION 2.8.5)
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../cmake")
+
+include(add_dev_configuration)
+project(osmium-road-length)
 
 find_package(Boost REQUIRED)
 include_directories(SYSTEM ${Boost_INCLUDE_DIRS})


### PR DESCRIPTION
Currently cmake gives errors on Windows (seems to be cmake bug-feature https://cmake.org/Bug/view.php?id=6788 )

Workaround from osmium-tool.
Maybe appveyor would be good too...